### PR TITLE
Add support for alda play --history

### DIFF
--- a/src/alda/AldaRequestOptions.java
+++ b/src/alda/AldaRequestOptions.java
@@ -5,5 +5,5 @@ public class AldaRequestOptions {
   public String filename;
   public String from;
   public String to;
+  public String history;
 }
-

--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -239,6 +239,11 @@ public class AldaServer extends AldaProcess {
   }
 
   public void play(String code, String from, String to)
+    throws NoResponseException{
+    play(code, null, from, to);
+  }
+
+  public void play(String code, String history, String from, String to)
     throws NoResponseException {
 
     AldaRequest req = new AldaRequest(this.host, this.port);
@@ -251,6 +256,11 @@ public class AldaServer extends AldaProcess {
     if (to != null) {
       req.options.to = to;
     }
+
+    if (history != null) {
+      req.options.history = history;
+    }
+
     // play requests need to be sent exactly once and not retried, otherwise
     // the score could be played more than once.
     //

--- a/src/alda/Main.java
+++ b/src/alda/Main.java
@@ -103,6 +103,10 @@ public class Main {
                description = "Supply Alda code as a string")
     public String code;
 
+    @Parameter(names = {"-i", "--history"},
+               description = "Alda code that can be referenced but will not be played")
+    public String history = "";
+
     @Parameter(names = {"-F", "--from"},
                description = "A time marking or marker from which to start " +
                              "playback")
@@ -281,7 +285,7 @@ public class Main {
               server.play(play.file, play.from, play.to);
               break;
             case "code":
-              server.play(play.code, play.from, play.to);
+              server.play(play.code, play.history, play.from, play.to);
               break;
             case "stdin":
               server.play(Util.getStdIn(), play.from, play.to);


### PR DESCRIPTION
Send history to server as passed by the user. Allows for specifying
things like `(tempo! 500)` and other references without having them in
the code segment.

I'm fairly certain I got this one right, but let me know if you find anything wrong!

Blocked by alda-lang/alda-server-clj#4
Blocking #1 

Once both this and the above are finished, I'll start work on the java repl! :smile: 