### PR TITLE
Reset save overwrite warnings after a :new

### DIFF
--- a/src/alda/repl/commands/ReplCommand.java
+++ b/src/alda/repl/commands/ReplCommand.java
@@ -58,4 +58,12 @@ public interface ReplCommand {
    * @return the key to trigger, eg: 'help'
    */
   public String key();
+
+  /**
+   * Reset's any internal state this command has.
+   * Useful to reset state when :new is called
+   */
+  public default void reset() {
+    return;
+  }
 }

--- a/src/alda/repl/commands/ReplCommandManager.java
+++ b/src/alda/repl/commands/ReplCommandManager.java
@@ -4,6 +4,7 @@ package alda.repl.commands;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
+import java.util.Iterator;
 
 import jline.console.ConsoleReader;
 import alda.AldaServer;
@@ -12,7 +13,7 @@ import alda.AldaServer;
  * Class to manage and store all ReplCommands.
  * The ReplHelp objecct uses this to generate it's list of documentation.
  */
-public class ReplCommandManager {
+public class ReplCommandManager implements Iterable<ReplCommand> {
 
   private Map<String, ReplCommand> commands;
 
@@ -23,7 +24,7 @@ public class ReplCommandManager {
 
     // Temp array to store commands so we can iterate over them later
     ReplCommand[] cmds = {new ReplPlay(),
-                          new ReplNew(),
+                          new ReplNew(this),
                           new ReplQuit(),
                           new ReplScore(),
                           new ReplMap(),
@@ -53,5 +54,17 @@ public class ReplCommandManager {
    */
   public Collection<ReplCommand> values() {
     return commands.values();
+  }
+
+  /**
+   * Runs a function over every command we have stored.
+   * @param func The function to run on each command.
+   */
+  public Iterator<ReplCommand> iterator() {
+    // Create a iterator over all the values in command.
+    return commands.entrySet()
+      .stream()
+      .map(Map.Entry::getValue)
+      .iterator();
   }
 }

--- a/src/alda/repl/commands/ReplNew.java
+++ b/src/alda/repl/commands/ReplNew.java
@@ -11,12 +11,22 @@ import jline.console.ConsoleReader;
  * Simply deletes the contents of the stringbuffer passed into it
  */
 public class ReplNew implements ReplCommand {
+
+  private ReplCommandManager cmdManager;
+
+  public ReplNew(ReplCommandManager m) {
+    cmdManager = m;
+  }
+
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument) {
     history.delete(0, history.length());
     newInstrument.accept(null);
+    // Reset state of all commands
+    cmdManager.forEach(ReplCommand::reset);
   }
+
   @Override
   public String docSummary() {
     return "Creates a new score.";

--- a/src/alda/repl/commands/ReplSave.java
+++ b/src/alda/repl/commands/ReplSave.java
@@ -69,4 +69,9 @@ public class ReplSave implements ReplCommand {
   public String key() {
     return "save";
   }
+
+  @Override
+  public void reset() {
+    oldSaveFile = null;
+  }
 }


### PR DESCRIPTION
Closes #14.

To do this, this creates a new optional method that commands can implement, `reset`, to reset their internal state. This method is meant to be called in any instance that internal state would need to be cleared (such as `:new`). There might be other commands that need their state cleared, but I can't think of any on the top of my head, but they would be trivial to implement.