### PR TITLE
Prompt for overwrite before a :load or a :new

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -18,7 +18,7 @@
                   [us.bpsm/edn-java                 "0.4.6"]
                   [com.jcabi/jcabi-manifests        "1.1"]
                   [org.zeromq/jeromq                "0.4.0"]
-                  [jline                            "2.12.1"]])
+                  [jline                            "2.14.3"]])
 
 (require '[adzerk.bootlaces         :refer :all]
          '[radicalzephyr.boot-junit :refer (junit)])

--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -79,13 +79,13 @@ public final class Util {
 
   /**
    * Small wrapper to make prompts easier to output.
-   * WARNING: This exits the whole program if any read error is given.
+   * WARNING: This exits the whole program if any read error is given (and is unchecked).
    * @param r The console reader to input on
    * @param choices A varargs of choices to give
    * @param prompt The prompt to display above the choice.
    * @return The choice selected by the user.
    */
-  public static String uncheckedPromptWithChoices(ConsoleReader r, String prompt, String... choices) {
+  public static String promptWithChoices(ConsoleReader r, String prompt, String... choices) {
     try {
       System.out.println(prompt);
       return promptWithChoices(r, Arrays.asList(choices));

--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -77,6 +77,26 @@ public final class Util {
     return m.get(c);
   }
 
+  /**
+   * Small wrapper to make prompts easier to output.
+   * WARNING: This exits the whole program if any read error is given.
+   * @param r The console reader to input on
+   * @param choices A varargs of choices to give
+   * @param prompt The prompt to display above the choice.
+   * @return The choice selected by the user.
+   */
+  public static String uncheckedPromptWithChoices(ConsoleReader r, String prompt, String... choices) {
+    try {
+      System.out.println(prompt);
+      return promptWithChoices(r, Arrays.asList(choices));
+    } catch (IOException e) {
+      System.err.println("There was an error reading input!");
+      e.printStackTrace();
+      System.exit(1);
+    }
+    return null;
+  }
+
   public static boolean promptForConfirmation(String prompt) {
     Console console = System.console();
     if (System.console() != null) {

--- a/src/alda/repl/commands/ReplCommand.java
+++ b/src/alda/repl/commands/ReplCommand.java
@@ -1,9 +1,12 @@
 
 package alda.repl.commands;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.function.Consumer;
 
 import alda.AldaServer;
-import java.util.function.Consumer;
 import alda.AldaResponse.AldaScore;
 import jline.console.ConsoleReader;
 
@@ -14,6 +17,9 @@ import jline.console.ConsoleReader;
  * such as :help, :load, or :play
  */
 public interface ReplCommand {
+
+  public static final Set<String> YES_ALIASES = new HashSet<>(Arrays.asList("yes", "true", "on", "+", "y"));
+  public static final Set<String> NO_ALIASES = new HashSet<>(Arrays.asList("no", "false", "off", "-", "n"));
 
   /**
    * Runs this ReplCommand given the selected history.

--- a/src/alda/repl/commands/ReplDebug.java
+++ b/src/alda/repl/commands/ReplDebug.java
@@ -6,8 +6,6 @@ import alda.AldaResponse.AldaScore;
 import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
-import java.util.Set;
-import java.util.HashSet;
 import java.util.Arrays;
 
 /**
@@ -16,20 +14,16 @@ import java.util.Arrays;
  */
 public class ReplDebug implements ReplCommand {
 
-  // TODO find a better place to share these lists from
-  public static final Set<String> YES_ALIASES = new HashSet<>(Arrays.asList("yes", "true", "on", "+"));
-  public static final Set<String> NO_ALIASES = new HashSet<>(Arrays.asList("no", "false", "off", "-"));
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument) {
     // If no args, toggle debug flag
     if (args.length() == 0) {
       AldaRequest.setDebug(!AldaRequest.getDebug());
-    } else if (YES_ALIASES.contains(args.toLowerCase())) {
+    } else if (ReplCommand.YES_ALIASES.contains(args.toLowerCase())) {
       // force on
       AldaRequest.setDebug(true);
-    } else if (NO_ALIASES.contains(args.toLowerCase())) {
+    } else if (ReplCommand.NO_ALIASES.contains(args.toLowerCase())) {
       // force off
       AldaRequest.setDebug(false);
     } else {

--- a/src/alda/repl/commands/ReplLoad.java
+++ b/src/alda/repl/commands/ReplLoad.java
@@ -86,8 +86,8 @@ public class ReplLoad implements ReplCommand {
 
       if (!error) {
         // Check if we can continue overwrite.
-        if (Util.uncheckedPromptWithChoices(reader, OVERWRITE_WARNING,
-                                            "yes", "no") == "yes"){
+        if (Util.promptWithChoices(reader, OVERWRITE_WARNING,
+                                            "yes", "no").equals("yes")){
           history.delete(0, history.length());
           history.append(newHistory);
 

--- a/src/alda/repl/commands/ReplLoad.java
+++ b/src/alda/repl/commands/ReplLoad.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardOpenOption;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 import java.util.function.Consumer;
 
@@ -45,7 +46,7 @@ public class ReplLoad implements ReplCommand {
    * @args history buffer to modify
    */
   private void loadFile(String args, AldaServer server, StringBuffer history,
-                        Consumer<AldaScore> newInstrument)
+                        ConsoleReader reader, Consumer<AldaScore> newInstrument)
   throws alda.NoResponseException {
     Stream<String> fLines = null;
     boolean error = false;
@@ -82,7 +83,8 @@ public class ReplLoad implements ReplCommand {
 
       if (!error) {
         // Check if we can continue overwrite.
-        if (promptOverwrite(history, reader)){
+        System.out.println("This action will overwrite the current score. Continue?");
+        if (Util.promptWithChoices(reader, Arrays.asList("yes", "no")) == "yes"){
           history.delete(0, history.length());
           history.append(newHistory);
 
@@ -118,26 +120,6 @@ public class ReplLoad implements ReplCommand {
     // Turn ~ into home
     args = args.replaceFirst("^~",System.getProperty("user.home"));
     loadFile(args, server, history, reader, newInstrument);
-  }
-
-  /**
-   * Prompt for overwriting the current contents
-   * @return if true, continue overwite.
-   */
-  public static boolean promptOverwrite(CharSequence seq, ConsoleReader reader) {
-    if (seq.length() == 0 || seq == null) {
-      // Don't worry if there's nothing to overwrite.
-      return true;
-    }
-    try {
-      String confirm = reader.readLine("Action will overwrite current score, continue [y/N]: ");
-      if (confirm.equalsIgnoreCase("y") || confirm.equalsIgnoreCase("yes")) {
-        return true;
-      }
-      return false;
-    } catch (IOException e) {
-      return false;
-    }
   }
 
   @Override

--- a/src/alda/repl/commands/ReplLoad.java
+++ b/src/alda/repl/commands/ReplLoad.java
@@ -26,6 +26,9 @@ import jline.console.ConsoleReader;
  */
 public class ReplLoad implements ReplCommand {
 
+  public static final String OVERWRITE_WARNING =
+    "This action will overwrite the current score. Continue?";
+
   private ReplCommandManager cmdManager;
 
   public ReplLoad(ReplCommandManager m) {
@@ -83,8 +86,8 @@ public class ReplLoad implements ReplCommand {
 
       if (!error) {
         // Check if we can continue overwrite.
-        System.out.println("This action will overwrite the current score. Continue?");
-        if (Util.promptWithChoices(reader, Arrays.asList("yes", "no")) == "yes"){
+        if (Util.uncheckedPromptWithChoices(reader, OVERWRITE_WARNING,
+                                            "yes", "no") == "yes"){
           history.delete(0, history.length());
           history.append(newHistory);
 

--- a/src/alda/repl/commands/ReplNew.java
+++ b/src/alda/repl/commands/ReplNew.java
@@ -20,6 +20,14 @@ public class ReplNew implements ReplCommand {
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument) {
+
+    if (history.length() > 0) {
+      // Verify we can delete score
+      if (!ReplLoad.promptOverwrite(history, reader)) {
+        return;
+      }
+    }
+
     // Clear history
     history.delete(0, history.length());
     // Clear prompt

--- a/src/alda/repl/commands/ReplNew.java
+++ b/src/alda/repl/commands/ReplNew.java
@@ -27,15 +27,9 @@ public class ReplNew implements ReplCommand {
 
     if (history.length() > 0) {
       // Verify we can delete score
-      try {
-        System.out.println("This action will overwrite the current score. Continue?");
-        if (Util.promptWithChoices(reader, Arrays.asList("yes", "no")) != "yes") {
-          return;
-        }
-      } catch (IOException e) {
-        System.err.println("There was an error reading input.");
-        e.printStackTrace();
-        System.exit(1);
+      if (Util.uncheckedPromptWithChoices(reader, ReplLoad.OVERWRITE_WARNING,
+                                          "yes", "no") != "yes") {
+        return;
       }
     }
 

--- a/src/alda/repl/commands/ReplNew.java
+++ b/src/alda/repl/commands/ReplNew.java
@@ -1,7 +1,11 @@
 
 package alda.repl.commands;
 
+import java.util.Arrays;
+import java.io.IOException;
+
 import alda.AldaServer;
+import alda.Util;
 import alda.AldaResponse.AldaScore;
 import java.util.function.Consumer;
 import jline.console.ConsoleReader;
@@ -23,8 +27,15 @@ public class ReplNew implements ReplCommand {
 
     if (history.length() > 0) {
       // Verify we can delete score
-      if (!ReplLoad.promptOverwrite(history, reader)) {
-        return;
+      try {
+        System.out.println("This action will overwrite the current score. Continue?");
+        if (Util.promptWithChoices(reader, Arrays.asList("yes", "no")) != "yes") {
+          return;
+        }
+      } catch (IOException e) {
+        System.err.println("There was an error reading input.");
+        e.printStackTrace();
+        System.exit(1);
       }
     }
 

--- a/src/alda/repl/commands/ReplNew.java
+++ b/src/alda/repl/commands/ReplNew.java
@@ -27,8 +27,8 @@ public class ReplNew implements ReplCommand {
 
     if (history.length() > 0) {
       // Verify we can delete score
-      if (Util.uncheckedPromptWithChoices(reader, ReplLoad.OVERWRITE_WARNING,
-                                          "yes", "no") != "yes") {
+      if (!Util.promptWithChoices(reader, ReplLoad.OVERWRITE_WARNING,
+                                          "yes", "no").equals("yes")) {
         return;
       }
     }

--- a/src/alda/repl/commands/ReplQuit.java
+++ b/src/alda/repl/commands/ReplQuit.java
@@ -17,7 +17,7 @@ public  class ReplQuit implements ReplCommand {
     if (history.length() == 0 ||
         Util.promptWithChoices(
           reader,
-          "Are you sure you want to quit (destroying unsaved changes)?",
+          "You have unsaved changes. Are you sure you want to quit?",
           "yes", "no").equals("yes")) {
       // Bye! =)
       System.exit(0);

--- a/src/alda/repl/commands/ReplQuit.java
+++ b/src/alda/repl/commands/ReplQuit.java
@@ -1,6 +1,7 @@
 package alda.repl.commands;
 
 import alda.AldaServer;
+import alda.Util;
 import alda.AldaResponse.AldaScore;
 import java.util.function.Consumer;
 import jline.console.ConsoleReader;
@@ -13,8 +14,14 @@ public  class ReplQuit implements ReplCommand {
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument) {
-    // Bye! =)
-    System.exit(0);
+    if (history.length() == 0 ||
+        Util.promptWithChoices(
+          reader,
+          "Are you sure you want to quit (destroying unsaved changes)?",
+          "yes", "no").equals("yes")) {
+      // Bye! =)
+      System.exit(0);
+    }
   }
   @Override
   public String docSummary() {

--- a/src/alda/repl/commands/ReplSave.java
+++ b/src/alda/repl/commands/ReplSave.java
@@ -54,8 +54,8 @@ public class ReplSave implements ReplCommand {
         Files.write(Paths.get(args), history.toString().getBytes(), StandardOpenOption.CREATE_NEW);
         setOldSaveFile(args);
       } catch (FileAlreadyExistsException e) {
-        String confirm = reader.readLine("File already present, overwrite? [y/n]: ");
-        if (confirm.equalsIgnoreCase("y") || confirm.equalsIgnoreCase("yes")) {
+        String confirm = reader.readLine("File already present, overwrite? [y/N]: ");
+        if (ReplCommand.YES_ALIASES.contains(confirm.toLowerCase())) {
           Files.write(Paths.get(args), history.toString().getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
           setOldSaveFile(args);
         }

--- a/src/alda/repl/commands/ReplSave.java
+++ b/src/alda/repl/commands/ReplSave.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 
 import alda.AldaServer;
+import alda.Util;
 import alda.AldaResponse.AldaScore;
 import java.util.function.Consumer;
 import jline.console.ConsoleReader;
@@ -51,12 +52,16 @@ public class ReplSave implements ReplCommand {
       }
 
       try {
-        Files.write(Paths.get(args), history.toString().getBytes(), StandardOpenOption.CREATE_NEW);
+        Files.write(Paths.get(args), history.toString().getBytes(),
+                    StandardOpenOption.CREATE_NEW);
         setOldSaveFile(args);
       } catch (FileAlreadyExistsException e) {
-        String confirm = reader.readLine("File already present, overwrite? [y/N]: ");
-        if (ReplCommand.YES_ALIASES.contains(confirm.toLowerCase())) {
-          Files.write(Paths.get(args), history.toString().getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        if (Util.uncheckedPromptWithChoices(reader,
+                                            "File already present, overwrite?",
+                                            "yes", "no") == "yes") {
+          Files.write(Paths.get(args), history.toString().getBytes(),
+                      StandardOpenOption.CREATE,
+                      StandardOpenOption.TRUNCATE_EXISTING);
           setOldSaveFile(args);
         }
       }

--- a/src/alda/repl/commands/ReplSave.java
+++ b/src/alda/repl/commands/ReplSave.java
@@ -56,9 +56,9 @@ public class ReplSave implements ReplCommand {
                     StandardOpenOption.CREATE_NEW);
         setOldSaveFile(args);
       } catch (FileAlreadyExistsException e) {
-        if (Util.uncheckedPromptWithChoices(reader,
+        if (Util.promptWithChoices(reader,
                                             "File already present, overwrite?",
-                                            "yes", "no") == "yes") {
+                                            "yes", "no").equals("yes")) {
           Files.write(Paths.get(args), history.toString().getBytes(),
                       StandardOpenOption.CREATE,
                       StandardOpenOption.TRUNCATE_EXISTING);


### PR DESCRIPTION
This PR adds a very basic prompt when loading or saving. Right now, it dosen't compare the old/new buffers at all, it just warns the user when the score is non-nil (I'm not sure if we should make that a special case, since most of the time, a load/new does overwrite the current score).

I also added a quick check to see if a file exists before loading it, and print out a different error message instead of a generic read error.

I personally don't like the idea of a fancier dialog (abort, save, discard), since we would need to explain that in the message, making it a lot longer and confusing (vs muscle memory of hitting y/n). If you think that we should still have this feature I'll go ahead and add it, though.

Let me know if you find anything wrong! :)