### PR TITLE
Better handling of System.exit

### DIFF
--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -203,15 +203,6 @@ public class AldaServer extends AldaProcess {
     Util.callClojureFn("alda.server/start-server!", args);
   }
 
-  // TODO: rewrite REPL as a client that communicates with a server
-  public void startRepl() throws InvalidOptionsException {
-    assertNotRemoteHost();
-
-    Object[] args = {};
-
-    Util.callClojureFn("alda.repl/start-repl!", args);
-  }
-
   public void down() throws NoResponseException {
     boolean serverAlreadyDown = !checkForConnection();
     if (serverAlreadyDown) {

--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -116,14 +116,15 @@ public class AldaServer extends AldaProcess {
     serverDown(false);
   }
 
-  public void upBg(int numberOfWorkers)
+  // Returns true if starting the server is successful.
+  public boolean upBg(int numberOfWorkers)
     throws InvalidOptionsException, NoResponseException {
     assertNotRemoteHost();
 
     boolean serverAlreadyUp = checkForConnection();
     if (serverAlreadyUp) {
       msg("Server already up.");
-      System.exit(1);
+      return false;
     }
 
     boolean serverAlreadyTryingToStart;
@@ -139,7 +140,7 @@ public class AldaServer extends AldaProcess {
     if (serverAlreadyTryingToStart) {
       msg("There is already a server trying to start on this port. Please " +
           "be patient -- this can take a while.");
-      System.exit(1);
+      return false;
     }
 
     Object[] opts = {"--host", host,
@@ -156,17 +157,17 @@ public class AldaServer extends AldaProcess {
         serverUp();
       } else {
         serverDown();
-        return;
+        return false;
       }
     } catch (URISyntaxException e) {
       error(String.format("Unable to fork '%s' into the background; " +
             " got URISyntaxException: %s", e.getInput(), e.getReason()));
-      System.exit(1);
+      return false;
     } catch (IOException e) {
       error(String.format("An IOException occurred trying to fork a " +
                           "background process: %s",
                           e.getMessage()));
-      System.exit(1);
+      return false;
     }
 
     msg("Starting worker processes...");
@@ -178,7 +179,7 @@ public class AldaServer extends AldaProcess {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         System.out.println("Thread interrupted.");
-        return;
+        return false;
       }
       AldaRequest req = new AldaRequest(host, port);
       req.command = "status";
@@ -193,6 +194,7 @@ public class AldaServer extends AldaProcess {
     }
 
     ready();
+    return true;
   }
 
   public void upFg(int numberOfWorkers) throws InvalidOptionsException {
@@ -227,11 +229,12 @@ public class AldaServer extends AldaProcess {
     }
   }
 
-  public void downUp(int numberOfWorkers)
+  // Returns true if starting the server is successful.
+  public boolean downUp(int numberOfWorkers)
     throws NoResponseException, InvalidOptionsException {
     down();
     System.out.println();
-    upBg(numberOfWorkers);
+    return upBg(numberOfWorkers);
   }
 
   public void status() {

--- a/src/alda/Main.java
+++ b/src/alda/Main.java
@@ -209,6 +209,9 @@ public class Main {
       String mode;
       String inputType;
 
+      // used for up and downup commands
+      boolean success;
+
       switch (command) {
         case "help":
           jc.usage();
@@ -242,8 +245,8 @@ public class Main {
         case "start-server":
         case "init":
           handleCommandSpecificHelp(jc, "up", startServer);
-          server.upBg(globalOpts.numberOfWorkers);
-          System.exit(0);
+          success = server.upBg(globalOpts.numberOfWorkers);
+          System.exit(success ? 0 : 1);
 
         case "down":
         case "stop-server":
@@ -254,8 +257,8 @@ public class Main {
         case "downup":
         case "restart-server":
           handleCommandSpecificHelp(jc, "restart-server", restartServer);
-          server.downUp(globalOpts.numberOfWorkers);
-          System.exit(0);
+          success = server.downUp(globalOpts.numberOfWorkers);
+          System.exit(success ? 0 : 1);
 
         case "list":
           handleCommandSpecificHelp(jc, "list", list);

--- a/src/alda/repl/AldaRepl.java
+++ b/src/alda/repl/AldaRepl.java
@@ -169,7 +169,6 @@ public class AldaRepl {
           } catch (Throwable e) {
             System.err.println("Unable to start server:");
             e.printStackTrace();
-            System.exit(1);
           }
           break;
         case "no":
@@ -184,7 +183,6 @@ public class AldaRepl {
     } catch (IOException e) {
       System.err.println("Error trying to read character:");
       e.printStackTrace();
-      System.exit(1);
     }
     System.out.println();
   }


### PR DESCRIPTION
When using Alda from the command line, it makes sense to exit(1) if something goes wrong, e.g. the server fails to start. But in an interactive REPL session, I think it makes more sense to print errors and let the user decide what to do.