### PR TITLE
REPL: server management commands

### DIFF
--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -23,6 +23,8 @@ public class AldaServer extends AldaProcess {
   private static final int BUSY_WORKER_TIMEOUT = 10000;      // ms
   private static final int BUSY_WORKER_RETRY_INTERVAL = 500; // ms
 
+  private static final int PAUSE_BEFORE_RESTARTING_SERVER = 500; // ms
+
   public AldaServer(String host, int port, int timeout, boolean verbose, boolean quiet) {
     this.host = normalizeHost(host);
     this.port = port;
@@ -233,6 +235,12 @@ public class AldaServer extends AldaProcess {
   public boolean downUp(int numberOfWorkers)
     throws NoResponseException, InvalidOptionsException {
     down();
+    try {
+      Thread.sleep(PAUSE_BEFORE_RESTARTING_SERVER);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      System.out.println("Thread interrupted.");
+    }
     System.out.println();
     return upBg(numberOfWorkers);
   }

--- a/src/alda/Main.java
+++ b/src/alda/Main.java
@@ -273,8 +273,7 @@ public class Main {
         case "version":
           handleCommandSpecificHelp(jc, "version", version);
           System.out.println("Client version: " + AldaClient.version());
-          System.out.println();
-          System.out.println("Server version:");
+          System.out.print("Server version: ");
           server.version();
           System.exit(0);
 

--- a/src/alda/repl/AldaRepl.java
+++ b/src/alda/repl/AldaRepl.java
@@ -248,16 +248,16 @@ public class AldaRepl {
             System.out.println();
             offerToStartServer();
           } catch (UserInterruptException e) {
-			try {
-			  // Quit the repl
-			  cmd.act(":quit", history, server, r, this::setPromptPrefix);
-			} catch (Exception ex) {
-			  // Give up.
-			  System.err.println("An unknown error occurred!");
-			  ex.printStackTrace();
-			  System.exit(1);
-			}
-		  }
+            try {
+              // Quit the repl
+              cmd.act(":quit", history, server, r, this::setPromptPrefix);
+            } catch (Exception ex) {
+              // Give up.
+              System.err.println("An unknown error occurred!");
+              ex.printStackTrace();
+              System.exit(1);
+            }
+          }
         } else {
           System.err.println("No command '" + splitString[0] + "' was found");
         }

--- a/src/alda/repl/commands/ReplCommand.java
+++ b/src/alda/repl/commands/ReplCommand.java
@@ -52,6 +52,11 @@ public interface ReplCommand {
     return "";
   }
 
+  public default boolean hasDocDetails() {
+    String docDetails = docDetails();
+    return docDetails != null && !docDetails.isEmpty();
+  }
+
   /**
    * Prints usage information for this command.
    * Useful when this command encounters an error

--- a/src/alda/repl/commands/ReplCommandManager.java
+++ b/src/alda/repl/commands/ReplCommandManager.java
@@ -23,15 +23,23 @@ public class ReplCommandManager {
     // To see the actual command implemnetations, see Repl*.java (for each command)
 
     // Temp array to store commands so we can iterate over them later
-    ReplCommand[] cmds = {new ReplPlay(),
-                          new ReplQuit(),
-                          new ReplScore(),
-                          new ReplMap(),
-                          new ReplDebug(),
-                          new ReplNew(this),
-                          new ReplLoad(this),
-                          new ReplSave(this),
-                          new ReplHelp(this)};
+    ReplCommand[] cmds = {
+      new ReplDebug(),
+      new ReplDown(),
+      new ReplDownUp(),
+      new ReplHelp(this),
+      new ReplList(),
+      new ReplLoad(this),
+      new ReplMap(),
+      new ReplNew(this),
+      new ReplPlay(),
+      new ReplQuit(),
+      new ReplSave(this),
+      new ReplScore(),
+      new ReplStatus(),
+      new ReplUp(),
+      new ReplVersion()
+    };
 
     for (ReplCommand c : cmds) {
       commands.put(c.key(), c);

--- a/src/alda/repl/commands/ReplDown.java
+++ b/src/alda/repl/commands/ReplDown.java
@@ -1,0 +1,31 @@
+package alda.repl.commands;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplDown implements ReplCommand {
+  public ReplDown() {}
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    server.setQuiet(false);
+    server.down();
+    server.setQuiet(true);
+  }
+
+  @Override
+  public String docSummary() {
+    return "Stops the Alda server.";
+  }
+
+  @Override
+  public String key() {
+    return "down";
+  }
+}

--- a/src/alda/repl/commands/ReplDown.java
+++ b/src/alda/repl/commands/ReplDown.java
@@ -8,8 +8,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplDown implements ReplCommand {
-  public ReplDown() {}
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)

--- a/src/alda/repl/commands/ReplDownUp.java
+++ b/src/alda/repl/commands/ReplDownUp.java
@@ -9,8 +9,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplDownUp implements ReplCommand {
-  public ReplDownUp() {}
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)

--- a/src/alda/repl/commands/ReplDownUp.java
+++ b/src/alda/repl/commands/ReplDownUp.java
@@ -1,0 +1,37 @@
+package alda.repl.commands;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+import alda.repl.AldaRepl;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplDownUp implements ReplCommand {
+  public ReplDownUp() {}
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    server.setQuiet(false);
+    try {
+      server.downUp(AldaRepl.DEFAULT_NUMBER_OF_WORKERS);
+    } catch (alda.InvalidOptionsException e) {
+      System.err.println("Unable to start server: ");
+      e.printStackTrace();
+    }
+    server.setQuiet(true);
+  }
+
+  @Override
+  public String docSummary() {
+    return "Restarts the Alda server.";
+  }
+
+  @Override
+  public String key() {
+    return "downup";
+  }
+}

--- a/src/alda/repl/commands/ReplHelp.java
+++ b/src/alda/repl/commands/ReplHelp.java
@@ -3,6 +3,7 @@ package alda.repl.commands;
 
 import alda.AldaServer;
 import alda.AldaResponse.AldaScore;
+import java.util.Collections;
 import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
@@ -29,11 +30,22 @@ public class ReplHelp implements ReplCommand {
                   ConsoleReader reader, Consumer<AldaScore> newInstrument) {
     args = args.trim();
 
+    // the length of the longest command
+    int maxKeyLength = cmdManager.values()
+                                 .stream()
+                                 .mapToInt(cmd -> cmd.key().length())
+                                 .max()
+                                 .getAsInt();
+
     // Print out default help info
     if (args.length() == 0) {
       System.out.println(HELP_HEADER);
       for (ReplCommand c : cmdManager.values()) {
-        System.out.println("    :" + c.key() + "\t" + c.docSummary()
+        String key = c.key();
+        int spaces = maxKeyLength - key.length() + 2;
+        String spacing = String.join("", Collections.nCopies(spaces, " "));
+
+        System.out.println("    :" + key + spacing + c.docSummary()
                            + (c.docDetails() != "" ? " (*)" : ""));
       }
       return;

--- a/src/alda/repl/commands/ReplHelp.java
+++ b/src/alda/repl/commands/ReplHelp.java
@@ -44,19 +44,19 @@ public class ReplHelp implements ReplCommand {
     if (args.length() == 0) {
       System.out.println(HELP_HEADER);
 
-      List<ReplCommand> sortedCmds = cmdManager.values()
-                                               .stream()
-                                               .sorted((cmd1, cmd2) -> cmd1.key().compareTo(cmd2.key()))
-                                               .collect(Collectors.toList());
-
-      for (ReplCommand c : sortedCmds) {
-        String key = c.key();
-        int spaces = maxKeyLength - key.length() + 2;
-        String spacing = String.join("", Collections.nCopies(spaces, " "));
-
-        System.out.println("    :" + key + spacing + c.docSummary()
-                           + (c.docDetails() != "" ? " (*)" : ""));
-      }
+      cmdManager
+        .values()
+        .stream()
+        .sorted((cmd1, cmd2) -> cmd1.key().compareTo(cmd2.key()))
+        .forEach(cmd -> {
+          String key = cmd.key();
+          int numberOfSpaces = maxKeyLength - key.length() + 2;
+          List<String> spaces = Collections.nCopies(numberOfSpaces, " ");
+          String spacing = String.join("", spaces);
+          System.out.println("    :" + key + spacing +
+                             cmd.docSummary() +
+                             (cmd.docDetails() != "" ? " (*)" : ""));
+        });
 
       System.out.println();
 

--- a/src/alda/repl/commands/ReplHelp.java
+++ b/src/alda/repl/commands/ReplHelp.java
@@ -57,9 +57,8 @@ public class ReplHelp implements ReplCommand {
       System.out.println(cmd.docSummary());
       if (cmd.docDetails() != "") {
         System.out.println();
-        for (String line : cmd.docDetails().split("\n")) {
-          System.out.println("   " + line);
-        }
+        System.out.println(cmd.docDetails());
+        System.out.println();
       }
     } else {
       System.err.println("No documentation was found for '" + args + "'.");

--- a/src/alda/repl/commands/ReplHelp.java
+++ b/src/alda/repl/commands/ReplHelp.java
@@ -3,8 +3,11 @@ package alda.repl.commands;
 
 import alda.AldaServer;
 import alda.AldaResponse.AldaScore;
+
+import java.util.List;
 import java.util.Collections;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import jline.console.ConsoleReader;
 
 /**
@@ -40,7 +43,13 @@ public class ReplHelp implements ReplCommand {
     // Print out default help info
     if (args.length() == 0) {
       System.out.println(HELP_HEADER);
-      for (ReplCommand c : cmdManager.values()) {
+
+      List<ReplCommand> sortedCmds = cmdManager.values()
+                                               .stream()
+                                               .sorted((cmd1, cmd2) -> cmd1.key().compareTo(cmd2.key()))
+                                               .collect(Collectors.toList());
+
+      for (ReplCommand c : sortedCmds) {
         String key = c.key();
         int spaces = maxKeyLength - key.length() + 2;
         String spacing = String.join("", Collections.nCopies(spaces, " "));
@@ -48,6 +57,9 @@ public class ReplHelp implements ReplCommand {
         System.out.println("    :" + key + spacing + c.docSummary()
                            + (c.docDetails() != "" ? " (*)" : ""));
       }
+
+      System.out.println();
+
       return;
     }
 

--- a/src/alda/repl/commands/ReplHelp.java
+++ b/src/alda/repl/commands/ReplHelp.java
@@ -55,7 +55,7 @@ public class ReplHelp implements ReplCommand {
           String spacing = String.join("", spaces);
           System.out.println("    :" + key + spacing +
                              cmd.docSummary() +
-                             (cmd.docDetails() != "" ? " (*)" : ""));
+                             (cmd.hasDocDetails() ? " (*)" : ""));
         });
 
       System.out.println();

--- a/src/alda/repl/commands/ReplList.java
+++ b/src/alda/repl/commands/ReplList.java
@@ -10,8 +10,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplList implements ReplCommand {
-  public ReplList() {}
-
   private static int LIST_PROCESSES_TIMEOUT = 5000;
 
   @Override

--- a/src/alda/repl/commands/ReplList.java
+++ b/src/alda/repl/commands/ReplList.java
@@ -1,0 +1,38 @@
+package alda.repl.commands;
+
+import alda.AldaClient;
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplList implements ReplCommand {
+  public ReplList() {}
+
+  private static int LIST_PROCESSES_TIMEOUT = 5000;
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    try {
+      AldaClient.listProcesses(LIST_PROCESSES_TIMEOUT);
+    } catch (IOException e) {
+      System.out.println("Error trying to list Alda processes:");
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public String docSummary() {
+    return "Lists running Alda processes.";
+  }
+
+  @Override
+  public String key() {
+    return "list";
+  }
+}

--- a/src/alda/repl/commands/ReplStatus.java
+++ b/src/alda/repl/commands/ReplStatus.java
@@ -8,8 +8,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplStatus implements ReplCommand {
-  public ReplStatus() {}
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)

--- a/src/alda/repl/commands/ReplStatus.java
+++ b/src/alda/repl/commands/ReplStatus.java
@@ -1,0 +1,39 @@
+package alda.repl.commands;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplStatus implements ReplCommand {
+  public ReplStatus() {}
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    server.setQuiet(false);
+    server.status();
+    server.setQuiet(true);
+  }
+
+  @Override
+  public String docSummary() {
+    return "Displays the status of the Alda server.";
+  }
+
+  @Override
+  public String docDetails() {
+    return "Status information includes:\n" +
+           "  * whether the server is up or down\n" +
+           "  * the backend port on which the server and workers communicate\n" +
+           "  * many worker processes are currently available";
+  }
+
+  @Override
+  public String key() {
+    return "status";
+  }
+}

--- a/src/alda/repl/commands/ReplUp.java
+++ b/src/alda/repl/commands/ReplUp.java
@@ -1,0 +1,37 @@
+package alda.repl.commands;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+import alda.repl.AldaRepl;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplUp implements ReplCommand {
+  public ReplUp() {}
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    server.setQuiet(false);
+    try {
+      server.upBg(AldaRepl.DEFAULT_NUMBER_OF_WORKERS);
+    } catch (alda.InvalidOptionsException e) {
+      System.err.println("Unable to start server: ");
+      e.printStackTrace();
+    }
+    server.setQuiet(true);
+  }
+
+  @Override
+  public String docSummary() {
+    return "Starts the Alda server.";
+  }
+
+  @Override
+  public String key() {
+    return "up";
+  }
+}

--- a/src/alda/repl/commands/ReplUp.java
+++ b/src/alda/repl/commands/ReplUp.java
@@ -9,8 +9,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplUp implements ReplCommand {
-  public ReplUp() {}
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)

--- a/src/alda/repl/commands/ReplVersion.java
+++ b/src/alda/repl/commands/ReplVersion.java
@@ -1,0 +1,34 @@
+package alda.repl.commands;
+
+import alda.AldaClient;
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplVersion implements ReplCommand {
+  public ReplVersion() {}
+
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    System.out.println("Client version: " + AldaClient.version());
+    System.out.print("Server version: ");
+    server.setQuiet(false);
+    server.version();
+    server.setQuiet(true);
+  }
+
+  @Override
+  public String docSummary() {
+    return "Displays the version numbers of the Alda server and client.";
+  }
+
+  @Override
+  public String key() {
+    return "version";
+  }
+}

--- a/src/alda/repl/commands/ReplVersion.java
+++ b/src/alda/repl/commands/ReplVersion.java
@@ -9,8 +9,6 @@ import java.util.function.Consumer;
 import jline.console.ConsoleReader;
 
 public class ReplVersion implements ReplCommand {
-  public ReplVersion() {}
-
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)


### PR DESCRIPTION
Closes #13.

This adds 6 new REPL commands, each equivalent to their CLI counterparts:

* `:status` - display the status of the server
* `:list` - list running Alda processes
* `:version` - display Alda client + server versions
* `:down` - stop the server
* `:up` - start the server
* `:downup` - restart the server

This PR also includes various aesthetic adjustments -- see the individual commits for details.