### PR TITLE
alda stop / repl :stop command

### DIFF
--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -100,22 +100,22 @@ public class AldaServer extends AldaProcess {
   private final String CHECKMARK = "\u2713";
   private final String X = "\u2717";
 
-  private void ready() {
+  private void announceReady() {
     msg(ansi().a("Ready ").fg(GREEN).a(CHECKMARK).reset().toString());
   }
 
-  private void serverUp() {
+  private void announceServerUp() {
     msg(ansi().a("Server up ").fg(GREEN).a(CHECKMARK).reset().toString());
   }
 
-  private void serverDown(boolean isGood) {
+  private void announceServerDown(boolean isGood) {
     Color color = isGood ? GREEN : RED;
     String glyph = isGood ? CHECKMARK : X;
     msg(ansi().a("Server down ").fg(color).a(glyph).reset().toString());
   }
 
-  private void serverDown() {
-    serverDown(false);
+  private void announceServerDown() {
+    announceServerDown(false);
   }
 
   // Returns true if starting the server is successful.
@@ -156,9 +156,9 @@ public class AldaServer extends AldaProcess {
 
       boolean serverUp = waitForConnection();
       if (serverUp) {
-        serverUp();
+        announceServerUp();
       } else {
-        serverDown();
+        announceServerDown();
         return false;
       }
     } catch (URISyntaxException e) {
@@ -195,7 +195,7 @@ public class AldaServer extends AldaProcess {
       }
     }
 
-    ready();
+    announceReady();
     return true;
   }
 
@@ -222,12 +222,12 @@ public class AldaServer extends AldaProcess {
     try {
       AldaResponse res = req.send();
       if (res.success) {
-        serverDown(true);
+        announceServerDown(true);
       } else {
         throw new NoResponseException("Failed to stop server.");
       }
     } catch (NoResponseException e) {
-      serverDown(true);
+      announceServerDown(true);
     }
   }
 
@@ -258,7 +258,7 @@ public class AldaServer extends AldaProcess {
         error(res.body);
       }
     } catch (NoResponseException e) {
-      serverDown();
+      announceServerDown();
     }
   }
 
@@ -454,7 +454,7 @@ public class AldaServer extends AldaProcess {
         error(res.body);
       }
     } catch (NoResponseException e) {
-      serverDown();
+      announceServerDown();
     }
   }
 

--- a/src/alda/AldaServer.java
+++ b/src/alda/AldaServer.java
@@ -441,6 +441,23 @@ public class AldaServer extends AldaProcess {
     return req.send();
   }
 
+  public void stop() {
+    AldaRequest req = new AldaRequest(host, port);
+    req.command = "stop-playback";
+
+    try {
+      AldaResponse res = req.send();
+
+      if (res.success) {
+        msg(res.body);
+      } else {
+        error(res.body);
+      }
+    } catch (NoResponseException e) {
+      serverDown();
+    }
+  }
+
   /**
    * Raw parsing function
    * @return Returns the result of the parse, or null if the parse failed (and no exception was thrown)

--- a/src/alda/Main.java
+++ b/src/alda/Main.java
@@ -123,6 +123,9 @@ public class Main {
     public String to;
   }
 
+  @Parameters(commandDescription = "Stop playback")
+  private static class CommandStop extends AldaCommand {}
+
   @Parameters(commandDescription = "Display the result of parsing Alda code")
   private static class CommandParse extends AldaCommand {
     @Parameter(names = {"-f", "--file"},
@@ -157,6 +160,7 @@ public class Main {
     CommandStatus        status        = new CommandStatus();
     CommandVersion       version       = new CommandVersion();
     CommandPlay          play          = new CommandPlay();
+    CommandStop          stop          = new CommandStop();
     CommandParse         parse         = new CommandParse();
 
     JCommander jc = new JCommander(globalOpts);
@@ -179,6 +183,7 @@ public class Main {
     jc.addCommand("version", version);
 
     jc.addCommand("play", play);
+    jc.addCommand("stop", stop, "stop-playback");
     jc.addCommand("parse", parse);
 
     try {
@@ -296,6 +301,12 @@ public class Main {
                                   "of a string, file, or STDIN.");
           }
           System.exit(0);
+
+        case "stop":
+        case "stop-playback":
+            handleCommandSpecificHelp(jc, "stop", stop);
+            server.stop();
+            break;
 
         case "parse":
           handleCommandSpecificHelp(jc, "parse", parse);

--- a/src/alda/repl/commands/ReplCommandManager.java
+++ b/src/alda/repl/commands/ReplCommandManager.java
@@ -1,4 +1,3 @@
-
 package alda.repl.commands;
 
 import java.util.Map;
@@ -10,7 +9,7 @@ import alda.AldaServer;
 
 /**
  * Class to manage and store all ReplCommands.
- * The ReplHelp objecct uses this to generate it's list of documentation.
+ * The ReplHelp object uses this to generate it's list of documentation.
  */
 public class ReplCommandManager {
 
@@ -36,6 +35,7 @@ public class ReplCommandManager {
       new ReplQuit(),
       new ReplSave(this),
       new ReplScore(),
+      new ReplStop(),
       new ReplStatus(),
       new ReplUp(),
       new ReplVersion()

--- a/src/alda/repl/commands/ReplStop.java
+++ b/src/alda/repl/commands/ReplStop.java
@@ -1,0 +1,27 @@
+package alda.repl.commands;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+
+import java.util.function.Consumer;
+
+import jline.console.ConsoleReader;
+
+public class ReplStop implements ReplCommand {
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+  throws alda.NoResponseException {
+    server.stop();
+  }
+
+  @Override
+  public String docSummary() {
+    return "Stops playback.";
+  }
+
+  @Override
+  public String key() {
+    return "stop";
+  }
+}


### PR DESCRIPTION
Sends a `stop-playback` request when you run `alda stop` at the command line or `:stop` in the REPL.

The code to stop the playback is implemented in:
https://github.com/alda-lang/alda-sound-engine-clj/pull/8
https://github.com/alda-lang/alda-server-clj/pull/9