### PR TITLE
Prevent downloading over the current executable

### DIFF
--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -200,6 +200,26 @@ public final class Util {
     }
   }
 
+  // Helper method to move files around, handling exceptions
+  public static boolean moveFile(File oldFile, File newFile) {
+    boolean success = false;
+    Exception toSave = null;
+    try {
+      success = oldFile.renameTo(newFile);
+    } catch (SecurityException e) {
+      success = false;
+      toSave = e;
+    } finally {
+      if (!success) {
+        System.err.println("There was an error copying '" + oldFile + "' to '" + newFile +  "'");
+        if (toSave != null)
+          toSave.printStackTrace();
+        return false;
+      }
+      return true;
+    }
+  }
+
   public static String readFile(File file) throws IOException {
     return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
   }


### PR DESCRIPTION
This approach creates a temp dir, moves the current executable to the
tmp dir, and download in place. If anything fails, we attempt to copy
the old executable back.

Hopefully eventually will close #24 (if tested/merged)

(per #24) could someone build me a windows version to test (still couldn't get that to work), with this patch: [lower-version.txt](https://github.com/alda-lang/alda-client-java/files/1076540/lower-version.txt)


WIP (not tested), so don't merge yet!