### PR TITLE
Add warning message to replace the windows updater

### DIFF
--- a/src/alda/AldaClient.java
+++ b/src/alda/AldaClient.java
@@ -2,6 +2,7 @@ package alda;
 
 import alda.error.UnsuccessfulException;
 import alda.error.SystemException;
+import alda.error.ExitCode;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -78,6 +79,17 @@ public class AldaClient {
         "Alda download link not found for your platform. Please file an " +
         "issue at: https://github.com/alda-lang/alda-client-java/issues/new"
       );
+    }
+
+    // Workaround for windows. See #24 #25
+    if (SystemUtils.IS_OS_WINDOWS) {
+      System.out.println("WARNING: The windows updater is currently disabled due to limitations in windows.");
+      System.out.println("For more infromation, see https://github.com/alda-lang/alda-client-java/issues/24");
+      System.out.println("To update alda, ensure all alda servers and clients are down and run the following command:\n");
+      System.out.println("powershell -Command Invoke-WebRequest -Uri \"" + downloadURL + "\" -OutFile \"" + programPath + "\"\n");
+      System.out.println("Or reinstall alda manually from https://github.com/alda-lang/alda/releases");
+      System.out.println("If that does not work, please reboot your system and try again.");
+      ExitCode.SUCCESS.exit();
     }
 
     // Request confirmation from user:

--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -14,8 +14,10 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URI;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -172,8 +174,8 @@ public final class Util {
   }
 
   public static String getProgramPath() throws URISyntaxException {
-    return Main.class.getProtectionDomain().getCodeSource().getLocation()
-               .toURI().getPath();
+    URI pathURI = Main.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+    return Paths.get(pathURI).toFile().toString();
   }
 
   public static String makeApiCall(String apiRequest) throws SystemException {


### PR DESCRIPTION
This disables the windows updater and replaces it with a message about how to upgrade alda. It also provides a command to download alda, which should work on all machines with windows 7+. If there is a problem writing to the file, it should warn the user (through the download command) about what the problem is (permissions, file lock, etc). 

Let me know if you think there's any way to improve this! :)

Closes #24, replaces #25