### PR TITLE
implement :info

### DIFF
--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -311,14 +311,12 @@ public final class Util {
     Clojure.var(var.getNamespace(), var.getName()).applyTo(argsSeq);
   }
   
-  public static class JsonElementBigIntegerComparator implements Comparator<JsonElement> {
-    public static JsonElementBigIntegerComparator INSTANCE = new JsonElementBigIntegerComparator();
+  public static class JsonElementFloatComparator implements Comparator<JsonElement> {
+    public static JsonElementFloatComparator INSTANCE = new JsonElementFloatComparator();
      
     @Override
     public int compare(JsonElement arg0, JsonElement arg1) {
-      BigInteger v0 = arg0.getAsBigInteger();
-      BigInteger v1 = arg1.getAsBigInteger();
-      return v0.compareTo(v1);
+      return Float.compare(arg0.getAsFloat(), arg1.getAsFloat());
     }
     
   }

--- a/src/alda/Util.java
+++ b/src/alda/Util.java
@@ -10,6 +10,7 @@ import java.io.Console;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.math.BigInteger;
 import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -19,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -307,5 +309,17 @@ public final class Util {
     require.invoke(Symbol.create(var.getNamespace()));
     ISeq argsSeq = ArraySeq.create(args);
     Clojure.var(var.getNamespace(), var.getName()).applyTo(argsSeq);
+  }
+  
+  public static class JsonElementBigIntegerComparator implements Comparator<JsonElement> {
+    public static JsonElementBigIntegerComparator INSTANCE = new JsonElementBigIntegerComparator();
+     
+    @Override
+    public int compare(JsonElement arg0, JsonElement arg1) {
+      BigInteger v0 = arg0.getAsBigInteger();
+      BigInteger v1 = arg1.getAsBigInteger();
+      return v0.compareTo(v1);
+    }
+    
   }
 }

--- a/src/alda/repl/commands/ReplCommandManager.java
+++ b/src/alda/repl/commands/ReplCommandManager.java
@@ -38,7 +38,8 @@ public class ReplCommandManager {
       new ReplStop(),
       new ReplStatus(),
       new ReplUp(),
-      new ReplVersion()
+      new ReplVersion(),
+      new ReplInfo()
     };
 
     for (ReplCommand c : cmds) {

--- a/src/alda/repl/commands/ReplInfo.java
+++ b/src/alda/repl/commands/ReplInfo.java
@@ -1,0 +1,103 @@
+package alda.repl.commands;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonParseException;
+
+import alda.AldaResponse.AldaScore;
+import alda.AldaServer;
+import alda.error.NoResponseException;
+import alda.error.ParseError;
+import jline.console.ConsoleReader;
+
+public class ReplInfo implements ReplCommand {
+  
+  private Gson gson = new Gson();
+	
+  @Override
+  public void act(String args, StringBuffer history, AldaServer server,
+                  ConsoleReader reader, Consumer<AldaScore> newInstrument)
+                		  throws NoResponseException {
+	try {
+	  String res = server.parseRaw(history.toString(), "data");
+	  if(res == null) {
+	    System.err.println("An internal error occurred when reading the score.");
+	  } else {
+        JsonObject scoreMap = gson.fromJson(res, JsonObject.class);
+  
+        StringBuilder sb = new StringBuilder();
+        sb.append("Instruments: ")
+        	.append(getInstrumentsString(scoreMap))
+        	.append(System.lineSeparator());
+        
+        sb.append("Current instruments: ")
+    		.append(getCurrentInstrumentsString(scoreMap))
+    		.append(System.lineSeparator());
+        
+        sb.append("Events: ")
+    		.append(getEventsAmount(scoreMap))
+    		.append(System.lineSeparator());
+     
+        sb.append("Markers: ")
+    		.append(getMarkersAmount(scoreMap))
+    		.append(System.lineSeparator());
+        
+		System.out.println(sb);
+	  }
+	  
+	} catch(ParseError e) {
+	  server.error(e.getMessage());
+	} catch(JsonParseException e) {
+	  server.error(e.getMessage());
+	} catch(ClassCastException e) {
+	  server.error(e.getMessage());
+	}
+    
+  }
+  
+  private String getInstrumentsString(JsonObject scoreMap) {
+    JsonObject instrJson = scoreMap.getAsJsonObject("instruments");
+	String instr = instrJson.entrySet()
+		.stream()
+		.map(e -> e.getKey())
+		.collect(Collectors.joining(", "));
+	return instr;
+  }
+
+  private String getCurrentInstrumentsString(JsonObject scoreMap) {
+    JsonArray curInstrJson = scoreMap.getAsJsonArray("current-instruments");
+    List<String> curInstrLst = gson.fromJson(curInstrJson, new TypeToken<List<String>>(){}.getType());
+	String instr = curInstrLst
+		.stream()
+		.collect(Collectors.joining(", "));
+	return instr;
+  }
+  
+  private int getMarkersAmount(JsonObject scoreMap) {
+    JsonObject markersJson = scoreMap.getAsJsonObject("markers");
+    int nMarkers = markersJson.entrySet().size() - 1;
+    return nMarkers;
+  }
+  
+  private int getEventsAmount(JsonObject scoreMap) {
+    JsonArray eventsJson = scoreMap.getAsJsonArray("events");
+    int nEvents = eventsJson.size();
+    return nEvents;
+  }
+  
+  @Override
+  public String docSummary() {
+    return "Print current score info.";
+  }
+
+  @Override
+  public String key() {
+    return "info";
+  }
+}

--- a/src/alda/repl/commands/ReplInfo.java
+++ b/src/alda/repl/commands/ReplInfo.java
@@ -1,17 +1,20 @@
 package alda.repl.commands;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 
 import alda.AldaResponse.AldaScore;
 import alda.AldaServer;
+import alda.Util;
 import alda.error.NoResponseException;
 import alda.error.ParseError;
 import jline.console.ConsoleReader;
@@ -19,70 +22,71 @@ import jline.console.ConsoleReader;
 public class ReplInfo implements ReplCommand {
   
   private Gson gson = new Gson();
-	
+  private final String NO_RESULTS_PLACEHOLDER = "(none)";
+  
   @Override
   public void act(String args, StringBuffer history, AldaServer server,
                   ConsoleReader reader, Consumer<AldaScore> newInstrument)
-                		  throws NoResponseException {
-	try {
-	  String res = server.parseRaw(history.toString(), "data");
-	  if(res == null) {
-	    System.err.println("An internal error occurred when reading the score.");
-	  } else {
+                      throws NoResponseException {
+  try {
+    String res = server.parseRaw(history.toString(), "data");
+    if(res == null) {
+      System.err.println("An internal error occurred when reading the score.");
+    } else {
         JsonObject scoreMap = gson.fromJson(res, JsonObject.class);
   
         StringBuilder sb = new StringBuilder();
         sb.append("Instruments: ")
-        	.append(getInstrumentsString(scoreMap))
-        	.append(System.lineSeparator());
+          .append(getInstrumentsString(scoreMap))
+          .append(System.lineSeparator());
         
         sb.append("Current instruments: ")
-    		.append(getCurrentInstrumentsString(scoreMap))
-    		.append(System.lineSeparator());
+        .append(getCurrentInstrumentsString(scoreMap))
+        .append(System.lineSeparator());
         
         sb.append("Events: ")
-    		.append(getEventsAmount(scoreMap))
-    		.append(System.lineSeparator());
+        .append(getEventsAmount(scoreMap))
+        .append(System.lineSeparator());
      
         sb.append("Markers: ")
-    		.append(getMarkersAmount(scoreMap))
-    		.append(System.lineSeparator());
+        .append(getMarkersString(scoreMap))
+        .append(System.lineSeparator());
         
-		System.out.println(sb);
-	  }
-	  
-	} catch(ParseError e) {
-	  server.error(e.getMessage());
-	} catch(JsonParseException e) {
-	  server.error(e.getMessage());
-	} catch(ClassCastException e) {
-	  server.error(e.getMessage());
-	}
+    System.out.println(sb);
+    }
+    
+  } catch(ParseError | JsonParseException e) {
+    server.error(e.getMessage());
+  }
     
   }
   
   private String getInstrumentsString(JsonObject scoreMap) {
     JsonObject instrJson = scoreMap.getAsJsonObject("instruments");
-	String instr = instrJson.entrySet()
-		.stream()
-		.map(e -> e.getKey())
-		.collect(Collectors.joining(", "));
-	return instr;
+    String instr = instrJson.entrySet()
+      .stream()
+      .map(e -> e.getKey())
+      .collect(Collectors.joining(", "));
+    return instr.length() == 0 ? NO_RESULTS_PLACEHOLDER : instr;
   }
 
   private String getCurrentInstrumentsString(JsonObject scoreMap) {
     JsonArray curInstrJson = scoreMap.getAsJsonArray("current-instruments");
     List<String> curInstrLst = gson.fromJson(curInstrJson, new TypeToken<List<String>>(){}.getType());
-	String instr = curInstrLst
-		.stream()
-		.collect(Collectors.joining(", "));
-	return instr;
+    String instr = curInstrLst
+      .stream()
+      .collect(Collectors.joining(", "));
+    return instr.length() == 0 ? NO_RESULTS_PLACEHOLDER : instr;
   }
   
-  private int getMarkersAmount(JsonObject scoreMap) {
+  private String getMarkersString(JsonObject scoreMap) {
     JsonObject markersJson = scoreMap.getAsJsonObject("markers");
-    int nMarkers = markersJson.entrySet().size() - 1;
-    return nMarkers;
+    String markers = markersJson.entrySet()
+      .stream()
+      .sorted(Comparator.comparing(Map.Entry::getValue, Util.JsonElementBigIntegerComparator.INSTANCE))
+      .map(e -> e.getKey())
+      .collect(Collectors.joining(", "));
+    return markers.length() == 0 ? NO_RESULTS_PLACEHOLDER : markers;
   }
   
   private int getEventsAmount(JsonObject scoreMap) {


### PR DESCRIPTION
Should solve #30 

Performed simple tests:
```
 unknown / development version
         repl session

Type :help for a list of available commands.

> :info
Instruments: 
Current instruments: 
Events: 0
Markers: 0

> :load sample.alda
This action will overwrite the current score. Continue?
(y)es, (n)o
c> 
c> :info
Instruments: violin-xTKq3, violin-tmlVg, viola-dK98h, cello-vuFTY
Current instruments: cello-vuFTY
Events: 20
Markers: 0

c> :quit
```
where sample.alda contains:
```
violin "violin-1":
  o4 f2   g4 a   b-2   a

violin "violin-2":
  o4 c2   e4 f   f2    f

viola:
  o3 a2 > c4 c   d2    c

cello:
  (volume 75)
  o3 f2   c4 f < b-2 > f
```


Please test it for some edge-case inputs too (sorry but I have yet no idea what scores would do the job).
Any change request, just let me know.